### PR TITLE
Ensure build artifacts are created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,4 @@ jobs:
       - run: yarn install
       - run: yarn build
       - run: yarn test
+      - run: yarn run check-git-clean

--- a/check-git-clean.sh
+++ b/check-git-clean.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+if ! git diff --quiet; then echo "
+
+The CI build resulted in additional changed files.
+Typically this is due to not running yarn build locally before
+submitting a pull request.
+
+The following changes were found:
+";
+
+  git diff --exit-code;
+fi;

--- a/flow/maybe.js
+++ b/flow/maybe.js
@@ -1,4 +1,4 @@
-declare module '@freckle/maybe' { 
+declare module '@freckle/maybe' {
 declare export function maybe<I, O>(
   defaultValue: () => O,
   f: (v: I) => O,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "tsc -d && node gen-flow.js",
     "test": "jest",
-    "format": "prettier --write 'src/**/*.ts'"
+    "format": "prettier --write 'src/**/*.ts'",
+    "check-git-clean": "./check-git-clean.sh"
   },
   "dependencies": {
     "lodash": "^4.17.21"

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -62,5 +62,3 @@ export function asHTMLAttributeValue<T>(value?: T | null): T | void {
   }
   return value
 }
-
-export const foo = (): string => 'hi'

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -62,3 +62,5 @@ export function asHTMLAttributeValue<T>(value?: T | null): T | void {
   }
   return value
 }
+
+export const foo = (): string => 'hi'


### PR DESCRIPTION
We'd like to ensure that `yarn build` is run locally to update the build artifacts when making changes to the library.

Cribbing the idea from https://github.com/immutable-js/immutable-js/blob/main/resources/check-git-clean.sh- this makes sure that `git diff` is clean when building on CI to accomplish that.

I tested making an update to `maybe.ts` and it does indeed fail the build https://github.com/freckle/maybe-js/runs/5686392833?check_suite_focus=true!