### PR TITLE
Generate flow types next to implementation

### DIFF
--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -1,0 +1,12 @@
+//@flow
+declare export {
+  maybe,
+  fromJust,
+  fromMaybe,
+  catMaybes,
+  mapMaybes,
+  mmap,
+  mthen,
+  mEffect,
+  asHTMLAttributeValue,
+} from "./maybe";

--- a/dist/maybe.js.flow
+++ b/dist/maybe.js.flow
@@ -1,4 +1,4 @@
-declare module '@freckle/maybe' {
+//@flow
 declare export function maybe<I, O>(
   defaultValue: () => O,
   f: (v: I) => O,
@@ -28,4 +28,3 @@ declare export function mEffect<V>(
   effect: (v: V) => void
 ): void;
 declare export function asHTMLAttributeValue<T>(value?: T | null): T | void;
-}

--- a/gen-flow.js
+++ b/gen-flow.js
@@ -1,16 +1,21 @@
 const {beautify, compiler} = require('flowgen')
 const fs = require('fs')
+const glob = require('glob')
+const path = require('path')
 
-const flowdef = beautify(compiler.compileDefinitionFile('./dist/maybe.d.ts'))
-fs.writeFile(
-  './flow/maybe.js',
-  `declare module '@freckle/maybe' \{
-${flowdef}\}
-`,
-  e => {
-    if (e) console.error(e)
-    else {
-      console.log('Flow types written')
-    }
-  }
-)
+glob('./dist/**/*.d.ts', {}, (err, files) => {
+  if (err) console.error(err)
+  files.forEach(f => {
+    const flowdef = beautify(compiler.compileDefinitionFile(f))
+    const p = path.parse(f)
+    const name = /(.*).d/.exec(p.name)[1]
+    fs.writeFile(
+      `${p.dir}/${name}.js.flow`,
+      `//@flow
+${flowdef}`,
+      e => {
+        if (e) console.error(e)
+      }
+    )
+  })
+})


### PR DESCRIPTION
We can use `*.js.flow` definitions alongside the `.js` files to direct flow where to look- this updates the script to generate those instead.