### PR TITLE
Use undefined instead of void for asHTMLAttributeValue

### DIFF
--- a/dist/maybe.d.ts
+++ b/dist/maybe.d.ts
@@ -6,4 +6,4 @@ export declare function mapMaybes<A, B>(array: Array<A>, callback: (value: A, in
 export declare const mmap: <I extends unknown, O>(f: (v: I) => O, v?: I | null | undefined) => O | null | undefined;
 export declare const mthen: <I extends unknown, O>(v: I | null | undefined, f: (v: I) => O | null | undefined) => O | null | undefined;
 export declare function mEffect<V>(v: V | undefined | null, effect: (v: V) => void): void;
-export declare function asHTMLAttributeValue<T>(value?: T | null): T | void;
+export declare function asHTMLAttributeValue<T>(value?: T | null): T | undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freckle/maybe",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Operations for maybe types",
   "main": "./dist/index.js",
   "repository": "https://github.com/freckle/maybe-js.git",

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -56,7 +56,7 @@ export function mEffect<V>(v: V | undefined | null, effect: (v: V) => void) {
  * <button {...disabledObj} />
  */
 
-export function asHTMLAttributeValue<T>(value?: T | null): T | void {
+export function asHTMLAttributeValue<T>(value?: T | null): T | undefined {
   if (value === null || value === undefined) {
     return undefined
   }


### PR DESCRIPTION
`void` is not the appropriate type here, it's for values that should never be observed. We mean `undefined` for this function.