### PR TITLE
Add `mObj`

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,1 @@
-export { maybe, fromJust, fromMaybe, catMaybes, mapMaybes, mmap, mthen, mEffect, asHTMLAttributeValue } from './maybe';
+export { maybe, fromJust, fromMaybe, catMaybes, mapMaybes, mmap, mthen, mEffect, mObj, asHTMLAttributeValue } from './maybe';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.asHTMLAttributeValue = exports.mEffect = exports.mthen = exports.mmap = exports.mapMaybes = exports.catMaybes = exports.fromMaybe = exports.fromJust = exports.maybe = void 0;
+exports.asHTMLAttributeValue = exports.mObj = exports.mEffect = exports.mthen = exports.mmap = exports.mapMaybes = exports.catMaybes = exports.fromMaybe = exports.fromJust = exports.maybe = void 0;
 var maybe_1 = require("./maybe");
 Object.defineProperty(exports, "maybe", { enumerable: true, get: function () { return maybe_1.maybe; } });
 Object.defineProperty(exports, "fromJust", { enumerable: true, get: function () { return maybe_1.fromJust; } });
@@ -10,4 +10,5 @@ Object.defineProperty(exports, "mapMaybes", { enumerable: true, get: function ()
 Object.defineProperty(exports, "mmap", { enumerable: true, get: function () { return maybe_1.mmap; } });
 Object.defineProperty(exports, "mthen", { enumerable: true, get: function () { return maybe_1.mthen; } });
 Object.defineProperty(exports, "mEffect", { enumerable: true, get: function () { return maybe_1.mEffect; } });
+Object.defineProperty(exports, "mObj", { enumerable: true, get: function () { return maybe_1.mObj; } });
 Object.defineProperty(exports, "asHTMLAttributeValue", { enumerable: true, get: function () { return maybe_1.asHTMLAttributeValue; } });

--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -8,5 +8,6 @@ declare export {
   mmap,
   mthen,
   mEffect,
+  mObj,
   asHTMLAttributeValue,
 } from "./maybe";

--- a/dist/maybe.d.ts
+++ b/dist/maybe.d.ts
@@ -6,4 +6,5 @@ export declare function mapMaybes<A, B>(array: Array<A>, callback: (value: A, in
 export declare const mmap: <I extends unknown, O>(f: (v: I) => O, v?: I | null | undefined) => O | null | undefined;
 export declare const mthen: <I extends unknown, O>(v: I | null | undefined, f: (v: I) => O | null | undefined) => O | null | undefined;
 export declare function mEffect<V>(v: V | undefined | null, effect: (v: V) => void): void;
+export declare const mObj: <P extends string, V>(p: P, v?: V | null | undefined) => Partial<Record<P, V>>;
 export declare function asHTMLAttributeValue<T>(value?: T | null): T | undefined;

--- a/dist/maybe.js
+++ b/dist/maybe.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.asHTMLAttributeValue = exports.mEffect = exports.mthen = exports.mmap = exports.mapMaybes = exports.catMaybes = exports.fromMaybe = exports.fromJust = exports.maybe = void 0;
+exports.asHTMLAttributeValue = exports.mObj = exports.mEffect = exports.mthen = exports.mmap = exports.mapMaybes = exports.catMaybes = exports.fromMaybe = exports.fromJust = exports.maybe = void 0;
 const map_1 = __importDefault(require("lodash/map"));
 const flatMap_1 = __importDefault(require("lodash/flatMap"));
 function maybe(defaultValue, f, v) {
@@ -43,6 +43,9 @@ function mEffect(v, effect) {
     }
 }
 exports.mEffect = mEffect;
+// create an object with the given property/value, when the value is present
+const mObj = (p, v) => v === null || v === undefined ? {} : { [p]: v };
+exports.mObj = mObj;
 /* asHTMLAttributeValue is used as a way to make an HTML attribute value
  * exist in the DOM or not. React does not add in the DOM HTML attributes
  * with an "undefined" value

--- a/dist/maybe.js.flow
+++ b/dist/maybe.js.flow
@@ -27,4 +27,8 @@ declare export function mEffect<V>(
   v: V | void | null,
   effect: (v: V) => void
 ): void;
+declare export var mObj: <P: string, V>(
+  p: P,
+  v?: V | null | void
+) => $Rest<{ [key: P]: V, ... }, { ... }>;
 declare export function asHTMLAttributeValue<T>(value?: T | null): T | void;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freckle/maybe",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Operations for maybe types",
   "main": "./dist/index.js",
   "repository": "https://github.com/freckle/maybe-js.git",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -109,15 +109,15 @@ describe('@freckle/maybe', () => {
 
   describe('mObj', () => {
     test('refines to a more specific type', () => {
-      const _ex1: { foo?: number } = mObj('foo', 42)
+      const _ex1: {foo?: number} = mObj('foo', 42)
       const mkNullNumber = (): null | number => null
-      const _ex2: { bar?: number } = mObj('bar', mkNullNumber())
-      const _ex3: { spam?: number } = mObj('spam', undefined)
+      const _ex2: {bar?: number} = mObj('bar', mkNullNumber())
+      const _ex3: {spam?: number} = mObj('spam', undefined)
     })
 
     test('returns an object with the given prop/value pair when the value is present', () => {
-      expect(mObj('eggs', 42)).toEqual({ eggs: 42 })
-      expect(mObj('fish', ['hi'])).toEqual({ fish: ['hi'] })
+      expect(mObj('eggs', 42)).toEqual({eggs: 42})
+      expect(mObj('fish', ['hi'])).toEqual({fish: ['hi']})
     })
 
     test('returns an empty object given null', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import {mapMaybes, mEffect, catMaybes, mmap, mthen} from '.'
+import {mapMaybes, mEffect, catMaybes, mmap, mthen, mObj} from '.'
 
 describe('@freckle/maybe', () => {
   describe('mapMaybes', () => {
@@ -104,6 +104,28 @@ describe('@freckle/maybe', () => {
       expect(fn).toHaveBeenCalledTimes(0)
       expect(returned1).toEqual(undefined)
       expect(returned2).toEqual(undefined)
+    })
+  })
+
+  describe('mObj', () => {
+    test('refines to a more specific type', () => {
+      const _ex1: { foo?: number } = mObj('foo', 42)
+      const mkNullNumber = (): null | number => null
+      const _ex2: { bar?: number } = mObj('bar', mkNullNumber())
+      const _ex3: { spam?: number } = mObj('spam', undefined)
+    })
+
+    test('returns an object with the given prop/value pair when the value is present', () => {
+      expect(mObj('eggs', 42)).toEqual({ eggs: 42 })
+      expect(mObj('fish', ['hi'])).toEqual({ fish: ['hi'] })
+    })
+
+    test('returns an empty object given null', () => {
+      expect(mObj('404', null)).toEqual({})
+    })
+
+    test('returns an empty object given undefined', () => {
+      expect(mObj('nope', undefined)).toEqual({})
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,6 @@ export {
   mmap,
   mthen,
   mEffect,
+  mObj,
   asHTMLAttributeValue
 } from './maybe'

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -45,6 +45,12 @@ export function mEffect<V>(v: V | undefined | null, effect: (v: V) => void) {
   }
 }
 
+// create an object with the given property/value, when the value is present
+export const mObj =  <P extends string, V>(p: P, v?: V | null): Partial<Record<P, V>> =>
+  v === null || v === undefined
+  ? {}
+  : {[p]: v} as Record<P, V>
+
 /* asHTMLAttributeValue is used as a way to make an HTML attribute value
  * exist in the DOM or not. React does not add in the DOM HTML attributes
  * with an "undefined" value

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -46,10 +46,8 @@ export function mEffect<V>(v: V | undefined | null, effect: (v: V) => void) {
 }
 
 // create an object with the given property/value, when the value is present
-export const mObj =  <P extends string, V>(p: P, v?: V | null): Partial<Record<P, V>> =>
-  v === null || v === undefined
-  ? {}
-  : {[p]: v} as Record<P, V>
+export const mObj = <P extends string, V>(p: P, v?: V | null): Partial<Record<P, V>> =>
+  v === null || v === undefined ? {} : ({[p]: v} as Record<P, V>)
 
 /* asHTMLAttributeValue is used as a way to make an HTML attribute value
  * exist in the DOM or not. React does not add in the DOM HTML attributes


### PR DESCRIPTION
See tests for example usages.

We do something like this _all the time_ in our codebase.

For example, we often build query params like

```javascript
let mParam: string | null

const params = {
  'param-1': 42,
  ...(mParam === undefined || mParam === null ? {} : { 'param-2': mParam })
}
```

This would now look like
```javascript
let mParam: string | null

const params = {
  'param-1': 42,
  ...mObj('param-2', mParam)
}
```

Major shout-out to Lucky who figured out how to type this thing correctly.