### PR TITLE
fix: run @semantic-release/npm before @semantic-release/git in prepare step

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -10,13 +10,13 @@ plugins:
   - - '@semantic-release/exec'
     - prepareCmd: 'yarn install && yarn run build'
 
+  - '@semantic-release/npm'
+
   - - '@semantic-release/git'
     - assets:
         - 'dist/**'
         - 'package.json' # commit updated version back to source
       message: 'chore(release): update dist and package.json'
-
-  - '@semantic-release/npm'
 
 branches:
   - main


### PR DESCRIPTION
## What's broken

`package.json` on `main` currently still reads `\"version\": \"2.2.1\"`, a full release behind, even though `v2.3.0` was tagged (and presumably published to npm). There is no `chore(release): update dist and package.json` commit anywhere in `main`'s history — the `v2.3.0` tag points directly at the `feat: add semantic-release with conventional commits` merge commit itself.

## Why

`.releaserc.yaml`'s `plugins` list previously ordered the `prepare`-step plugins as:

```
exec -> git -> npm
```

semantic-release executes plugins in the order they're defined, per lifecycle step ("plugins are executed in the order in which they are defined" — this is documented behavior, and npm-before-git is the ordering used in semantic-release's own example config). `@semantic-release/npm` is the plugin that actually writes the bumped version into `package.json`, but with the old ordering it ran *after* `@semantic-release/git` had already made its commit.

Concretely, at the moment `@semantic-release/git`'s `prepare` step ran, `package.json` was still untouched (npm hadn't bumped it yet) and the freshly-built `dist/**` was bit-for-bit identical to what was already committed — so `git` had nothing new to commit and silently no-op'd. `@semantic-release/npm` then ran afterward and published the bumped version to the npm registry, but that bump never made it back into the git repo.

This is the same class of bug independently flagged by @jleichty-ren reviewing a near-identical `.releaserc.yaml` in the sibling repo `freckle/cancelable-promise-js` (PR #152): "i think this order may miss the `package.json` version update. `@semantic-release/npm` updates the version, but it runs after `@semantic-release/git`. if we want `package.json` committed back to `main`, i think npm should run first."

## The fix

Reorder `.releaserc.yaml` so `@semantic-release/npm` runs before `@semantic-release/git` in the `prepare` step, so the version bump happens first and git's commit captures it. Only the relative order of the `npm` and `git` entries changes — everything else (comments, `exec`, `branches`, formatting/quoting style) is untouched.

```diff
-  - - '@semantic-release/git'
-    - assets:
-        - 'dist/**'
-        - 'package.json' # commit updated version back to source
-      message: 'chore(release): update dist and package.json'
-
-  - '@semantic-release/npm'
+  - '@semantic-release/npm'
+
+  - - '@semantic-release/git'
+    - assets:
+        - 'dist/**'
+        - 'package.json' # commit updated version back to source
+      message: 'chore(release): update dist and package.json'
```

This commit is itself a `fix:` so it will trigger a patch release once merged, which will also be the first release to correctly commit the version bump back to `main`.